### PR TITLE
Export HTML Escape helper

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub mod dumps;
 #[cfg(feature = "parsing")]
 pub mod easy;
 #[cfg(feature = "html")]
-mod escape;
+pub mod escape;
 pub mod highlighting;
 #[cfg(feature = "html")]
 pub mod html;


### PR DESCRIPTION
Exports the Escape helper, which is useful for when we need to write
HTML in a custom format. I also opened an upstream issue here:
https://github.com/trishume/syntect/issues/329

This will be used to build HTML tables in syntect rather than externally.